### PR TITLE
fix: fix python 3.7 imcompatibility

### DIFF
--- a/truelearn/learning/_base.py
+++ b/truelearn/learning/_base.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import Iterable, Hashable, Any, Optional, Tuple, Dict
 from typing_extensions import Self, Final, final
-import statistics
 import math
 import collections
 
 import trueskill
+import mpmath
 
 from truelearn.models import (
     EventModel,
@@ -76,7 +76,7 @@ class BaseClassifier(ABC):
         """
 
     @final
-    def get_params(self, deep: bool = True) -> dict[str, Any]:
+    def get_params(self, deep: bool = True) -> Dict[str, Any]:
         """Get parameters for this Classifier.
 
         Args:
@@ -475,7 +475,7 @@ def team_sum_quality(
 
     difference = sum(team_learner_mean) - sum(team_content_mean)
     std = math.sqrt(sum(team_learner_variance) + sum(team_content_variance) + beta)
-    return statistics.NormalDist(mu=0, sigma=std).cdf(difference)
+    return float(mpmath.ncdf(difference, mu=0, sigma=std))
 
 
 def select_topic_kc_pairs(

--- a/truelearn/learning/_ink_classifier.py
+++ b/truelearn/learning/_ink_classifier.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional, Dict
 from typing_extensions import Self, Final
 import math
-import statistics
 
 from ._base import BaseClassifier
 from ._novelty_classifier import NoveltyClassifier
@@ -9,6 +8,7 @@ from ._interest_classifier import InterestClassifier
 from truelearn.models import EventModel, LearnerMetaModel
 
 import trueskill
+import mpmath
 
 
 class INKClassifier(BaseClassifier):
@@ -169,7 +169,7 @@ class INKClassifier(BaseClassifier):
             + var_interest * pred_interest
             + var_bias * pred_bias
         )
-        return statistics.NormalDist(mu=0, sigma=std).cdf(difference)
+        return float(mpmath.ncdf(difference, mu=0, sigma=std))
 
     def __update_weights(
         self,


### PR DESCRIPTION
Fix incompatibility problems caused by using `dict[]` and `statistics.NormalDist` in Python 3.7.