### PR TITLE
Streamline CI behaviour

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,9 +42,9 @@ jobs:
         run: pip install pytest-cov
 
       - name: Calculate coverage
-        # Inc. branch + statement coverage
         run: |
-          pytest --cov-branch --cov-report "xml:coverage.xml" --cov=truelearn ./truelearn/tests
+          # Config in pyproject.toml
+          pytest --cov --cov-report "xml:coverage.xml" 
 
       - name: Update CodeCov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -49,7 +49,7 @@ jobs:
        # if: success()||failure()
         #with:
          # token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
-          #report: './prospector_report.json'
+          #report: './prospector_report.xml'
           #label: "Prospector Analysis Report"
 
       # NOTE: Because it expects Junit format, the line numberings on the annotation header defaults to 1

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           # Outputs the xunit report to project root
           # Uses prospector.yml config file
-          prospector --output-format xunit:prospector_report.json
+          prospector --output-format xunit:prospector_report.xml
 
      # Keep this commented out for now until prospector output format is fixed
      # - name: Convert test results to Github Annotations

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -41,24 +41,24 @@ jobs:
         run: |
           # Outputs the xunit report to project root
           # Uses prospector.yml config file
-          prospector --output-format xunit:prospector_report.xml
+          prospector --output-format xunit:prospector_report.json
 
       - name: Convert test results to Github Annotations
         uses: check-run-reporter/action@v2.11.1
         if: success()||failure()
         with:
           token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
-          report: './prospector_report.xml'
+          report: './prospector_report.json'
           label: "Prospector Analysis Report"
 
       # NOTE: Because it expects Junit format, the line numberings on the annotation header defaults to 1
       # However the error message shows the correct line numbering.
-      - name: Convert test results to Github Annotations
-        uses: mikepenz/action-junit-report@v3
+      #- name: Convert test results to Github Annotations
+       # uses: mikepenz/action-junit-report@v3
         # Use success()||failure() to allow for manual cancellation of an action (see docs)
-        if: success()||failure()
-        with:
+        #if: success()||failure()
+        #with:
           # Report in project root
-          report_paths: ./prospector_report.xml
-          check_name: "Prospector Analysis Report"
-          detailed_summary: true
+         # report_paths: ./prospector_report.xml
+          #check_name: "Prospector Analysis Report"
+          #detailed_summary: true

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -43,22 +43,23 @@ jobs:
           # Uses prospector.yml config file
           prospector --output-format xunit:prospector_report.json
 
-      - name: Convert test results to Github Annotations
-        uses: check-run-reporter/action@v2.11.1
-        if: success()||failure()
-        with:
-          token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
-          report: './prospector_report.json'
-          label: "Prospector Analysis Report"
+     # Keep this commented out for now until prospector output format is fixed
+     # - name: Convert test results to Github Annotations
+      #  uses: check-run-reporter/action@v2.11.1
+       # if: success()||failure()
+        #with:
+         # token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+          #report: './prospector_report.json'
+          #label: "Prospector Analysis Report"
 
       # NOTE: Because it expects Junit format, the line numberings on the annotation header defaults to 1
       # However the error message shows the correct line numbering.
-      #- name: Convert test results to Github Annotations
-       # uses: mikepenz/action-junit-report@v3
+      - name: Convert test results to Github Annotations
+        uses: mikepenz/action-junit-report@v3
         # Use success()||failure() to allow for manual cancellation of an action (see docs)
-        #if: success()||failure()
-        #with:
+        if: success()||failure()
+        with:
           # Report in project root
-         # report_paths: ./prospector_report.xml
-          #check_name: "Prospector Analysis Report"
-          #detailed_summary: true
+          report_paths: ./prospector_report.xml
+          check_name: "Prospector Analysis Report"
+          detailed_summary: true

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -43,6 +43,14 @@ jobs:
           # Uses prospector.yml config file
           prospector --output-format xunit:prospector_report.xml
 
+      - name: Convert test results to Github Annotations
+        uses: check-run-reporter/action@v2.11.1
+        if: success()||failure()
+        with:
+          token: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+          report: './prospector_report.xml'
+          label: "Prospector Analysis Report"
+
       # NOTE: Because it expects Junit format, the line numberings on the annotation header defaults to 1
       # However the error message shows the correct line numbering.
       - name: Convert test results to Github Annotations

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,7 +40,7 @@ jobs:
         # Pytest generates an XML report
       - name: Execute tests
         run: |
-         python -m pytest ./truelearn/tests --junitxml=unit_test_report.xml -v
+         pytest --junitxml=unit_test_report.xml
 
         # Convert the XML report to GitHub annotations
       - name: Convert test results to Github Annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,18 @@ target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 
 # ReadTheDocs have stated they wont support pyproject.toml config
 # See: https://github.com/readthedocs/readthedocs.org/issues/7065
+
+# Pytest config
+# See https://docs.pytest.org/en/stable/customize.html
+[tool.pytest.ini_options]
+addopts = "--verbose"
+testpaths = ["tests"]
+
+# Pytest-cov config (uses coverage.py)
+# See https://pytest-cov.readthedocs.io/en/latest/config.html
+[tool.coverage.run]
+# Include branch coverage (as well as statement coverage)
+branch = true
+source = ["truelearn"]
+omit = ["**/tests/*"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,13 +73,13 @@ target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 # See: https://github.com/readthedocs/readthedocs.org/issues/7065
 
 # Pytest config
-# See https://docs.pytest.org/en/stable/customize.html
+# See: https://docs.pytest.org/en/stable/customize.html
 [tool.pytest.ini_options]
 addopts = "--verbose"
 testpaths = ["tests"]
 
 # Pytest-cov config (uses coverage.py)
-# See https://pytest-cov.readthedocs.io/en/latest/config.html
+# See: https://pytest-cov.readthedocs.io/en/latest/config.html
 [tool.coverage.run]
 # Include branch coverage (as well as statement coverage)
 branch = true


### PR DESCRIPTION
- [x] Change config of CI workflows to pyproject.toml
- [x] Make coverage ignore test directory
~Change the action used to parse and output prospector warnings/errors (the current action doesnt parse the xunit xml correctly)~
 **UPDATE:** raised in PyCQA/prospector#593, I have tried different tools however this variation of xunit format isnt supported.