### PR TITLE
Refactor the user model and implement methods in the knowledge component

### DIFF
--- a/truelearn/models/__init__.py
+++ b/truelearn/models/__init__.py
@@ -2,12 +2,13 @@
 
 from ._abstract_knowledge import AbstractKnowledgeComponent
 from ._event_model import EventModel
-from ._knowledge import KnowledgeComponent, Knowledge
+from ._knowledge import KnowledgeComponent, HistoryAwareKnowledgeComponent, Knowledge
 from ._learner_model import LearnerModel, LearnerMetaModel
 
 __all__ = [
     "AbstractKnowledgeComponent",
     "KnowledgeComponent",
+    "HistoryAwareKnowledgeComponent",
     "Knowledge",
     "EventModel",
     "LearnerModel",

--- a/truelearn/models/_abstract_knowledge.py
+++ b/truelearn/models/_abstract_knowledge.py
@@ -76,11 +76,11 @@ class AbstractKnowledgeComponent(Protocol):
             *:
                 Use to reject positional arguments.
             mean:
-                The new mean of the AbstractKnowledgeComponent.
+                The new mean of the knowledge component.
             variance:
-                The new variance of the AbstractKnowledgeComponent.
+                The new variance of the knowledge component.
             timestamp:
-                An optional new POSIX timestamp of the AbstractKnowledgeComponent.
+                An optional new POSIX timestamp of the knowledge component.
 
         Returns:
             A cloned knowledge component with given mean, variance and timestamp.
@@ -88,7 +88,7 @@ class AbstractKnowledgeComponent(Protocol):
 
     @abstractmethod
     def export(self, output_format: str) -> Any:
-        """Export the AbstractKnowledgeComponent into some formats.
+        """Export the knowledge component into some formats.
 
         Args:
             output_format: The name of the output format.

--- a/truelearn/models/_abstract_knowledge.py
+++ b/truelearn/models/_abstract_knowledge.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 from typing_extensions import Self, Protocol
 
 
@@ -87,15 +87,13 @@ class AbstractKnowledgeComponent(Protocol):
         """
 
     @abstractmethod
-    def export(self, output_format: str) -> Any:
-        """Export the knowledge component into some formats.
+    def export_as_dict(self) -> Dict[str, Any]:
+        """Export the knowledge component into a dictionary.
 
         Args:
             output_format: The name of the output format.
 
         Returns:
-            The requested format.
-
-        Raises:
-            ValueError: An unsupported format is given.
+            A dictionary mapping the name of the variables to
+            their value.
         """

--- a/truelearn/models/_abstract_knowledge.py
+++ b/truelearn/models/_abstract_knowledge.py
@@ -1,9 +1,9 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, Optional
-from typing_extensions import Self
+from typing_extensions import Self, Protocol
 
 
-class AbstractKnowledgeComponent(ABC):
+class AbstractKnowledgeComponent(Protocol):
     """An interface defines a knowledge component of a learnable unit.
 
     Each knowledge component can be represented as a Normal Distribution with

--- a/truelearn/models/_abstract_knowledge.py
+++ b/truelearn/models/_abstract_knowledge.py
@@ -90,9 +90,6 @@ class AbstractKnowledgeComponent(Protocol):
     def export_as_dict(self) -> Dict[str, Any]:
         """Export the knowledge component into a dictionary.
 
-        Args:
-            output_format: The name of the output format.
-
         Returns:
             A dictionary mapping the name of the variables to
             their value.

--- a/truelearn/models/_knowledge.py
+++ b/truelearn/models/_knowledge.py
@@ -124,10 +124,15 @@ class KnowledgeComponent(AbstractKnowledgeComponent):
             url=self.__url,
         )
 
-    def export(self, output_format: str) -> Any:
-        raise NotImplementedError(
-            f"The export function for {output_format} is not yet implemented."
-        )
+    def export_as_dict(self) -> Any:
+        return {
+            "mean": self.__mean,
+            "variance": self.__variance,
+            "timestamp": self.__timestamp,
+            "title": self.__title,
+            "description": self.__description,
+            "url": self.__url,
+        }
 
 
 class HistoryAwareKnowledgeComponent(KnowledgeComponent):
@@ -224,10 +229,8 @@ class HistoryAwareKnowledgeComponent(KnowledgeComponent):
             history_limit=self.__history.maxlen,
         )
 
-    def export(self, output_format: str) -> Any:
-        raise NotImplementedError(
-            f"The export function for {output_format} is not yet implemented."
-        )
+    def export_as_dict(self) -> Any:
+        return {**super().export_as_dict(), "history": self.__history}
 
 
 class Knowledge:

--- a/truelearn/models/_knowledge.py
+++ b/truelearn/models/_knowledge.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Hashable, Any, Optional, Dict, Tuple
+import collections
+from typing import Iterable, Hashable, Any, Optional, Dict, Tuple, Deque
 from typing_extensions import Self
 
 from ._abstract_knowledge import AbstractKnowledgeComponent
@@ -121,6 +122,106 @@ class KnowledgeComponent(AbstractKnowledgeComponent):
             title=self.__title,
             description=self.__description,
             url=self.__url,
+        )
+
+    def export(self, output_format: str) -> Any:
+        raise NotImplementedError(
+            f"The export function for {output_format} is not yet implemented."
+        )
+
+
+class HistoryAwareKnowledgeComponent(KnowledgeComponent):
+    """A knowledge component that keeps a history about how it was updated."""
+
+    def __init__(
+        self,
+        *,
+        mean: float,
+        variance: float,
+        timestamp: Optional[float] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        history_limit: Optional[int] = None,
+        history: Optional[Deque[Tuple[float, float, Optional[float]]]] = None,
+    ) -> None:
+        """Init the KnowledgeComponent object.
+
+        Args:
+            mean:
+                A float indicating the mean of the knowledge component.
+            variance:
+                A float indicating the variance of the knowledge component.
+            timestamp:
+                A float indicating the POSIX timestamp of the last update of
+                the knowledge component.
+            title:
+                An optional string storing the title of the knowledge component.
+            description:
+                An optional string that describes the knowledge component.
+            url:
+                An optional string storing the url of the knowledge component.
+            history_limit:
+                A positive int that specifies the number of entries stored in the
+                history. If the limit is None, it means there is no limit.
+                Defaults to None.
+            history:
+                A queue that stores the update history of the knowledge component.
+                Each entry in the queue is a tuple (mean, variance, timestamp)
+                which records the mean and variance of this knowledge component
+                at the given timestamp.
+
+        Returns:
+            None.
+        """
+        super().__init__(
+            mean=mean,
+            variance=variance,
+            timestamp=timestamp,
+            title=title,
+            description=description,
+            url=url,
+        )
+
+        if history is None:
+            history = collections.deque(maxlen=history_limit)
+        else:
+            if history.maxlen != history_limit:
+                history = collections.deque(history, maxlen=history_limit)
+        self.__history = history
+
+    @property
+    def history(self) -> Deque[Tuple[float, float, Optional[float]]]:
+        """The update history of the current knowledge component."""
+        return self.__history
+
+    def update(
+        self,
+        *,
+        mean: Optional[float] = None,
+        variance: Optional[float] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self.__history.append((self.mean, self.variance, self.timestamp))
+
+        super().update(mean=mean, variance=variance, timestamp=timestamp)
+
+    def clone(
+        self,
+        *,
+        mean: float,
+        variance: float,
+        timestamp: Optional[float] = None,
+    ) -> Self:
+        return HistoryAwareKnowledgeComponent(
+            mean=mean,
+            variance=variance,
+            timestamp=timestamp,
+            title=self.__title,
+            description=self.__description,
+            url=self.__url,
+            history=self.__history.copy(),
+            history_limit=self.__history.maxlen,
         )
 
     def export(self, output_format: str) -> Any:

--- a/truelearn/models/_knowledge.py
+++ b/truelearn/models/_knowledge.py
@@ -194,19 +194,3 @@ class Knowledge:
     def knowledge_components(self) -> Iterable[AbstractKnowledgeComponent]:
         """Return an iterable of the knowledge component."""
         return self.__knowledge.values()
-
-    def export(self, output_format: str) -> Any:
-        """Export the knowledge into some formats.
-
-        Args:
-          output_format: The name of the output format
-
-        Returns:
-          Any: The requested format
-
-        Raises:
-            ValueError: An unsupported format is given.
-        """
-        raise NotImplementedError(
-            f"The export function for {output_format} is not yet implemented."
-        )

--- a/truelearn/models/_knowledge.py
+++ b/truelearn/models/_knowledge.py
@@ -124,7 +124,7 @@ class KnowledgeComponent(AbstractKnowledgeComponent):
             url=self.__url,
         )
 
-    def export_as_dict(self) -> Any:
+    def export_as_dict(self) -> Dict[str, Any]:
         return {
             "mean": self.__mean,
             "variance": self.__variance,
@@ -229,7 +229,7 @@ class HistoryAwareKnowledgeComponent(KnowledgeComponent):
             history_limit=self.__history.maxlen,
         )
 
-    def export_as_dict(self) -> Any:
+    def export_as_dict(self) -> Dict[str, Any]:
         return {**super().export_as_dict(), "history": self.__history}
 
 


### PR DESCRIPTION
## TODO

- [x] Change inheritance from `ABC` in AbstractKnowledgeComponent => inheritance from `Protocol`
- [x] Implement a knowledge component class that are capable of storing history
- [x] Implement the `export_as_dict` method in `KnowledgeComponent` and `HistoryAwareKnowledgeComponent`
    - I removed the `export` method because I think the ability to export knowledge component as JSON should be delegated to `truelearn.utils.persistent`. Therefore, I simply implemented the `export_as_dict` method, which exposes the internal state of the knowledge component. Then, the module in `truelearn.utils.persistent` is responsible for converting the returned dictionaries into their format.